### PR TITLE
improve use of build flags

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ LIB_DIR:= $(CWD)/lib
 DEP_DIR:= $(CWD)/deps
 
 CXX:=g++
-CXXFLAGS:=-std=c++11 -g
+CXXFLAGS += -std=c++11 -g
 
 ifeq ($(INCLUDE_FLAGS),)
 	# Include flags may be set by library user
@@ -42,89 +42,89 @@ clean:
 	rm -f $(BIN_DIR)/* $(OBJ_DIR)/*.o $(TEST_OBJ_DIR)/*.o $(LIB_DIR)/*
 
 tests : $(TEST_OBJ_DIR)/test.o $(CORE_OBJ) $(LIBHTS)
-	$(CXX) $(CXXFLAGS) $^ -o $(BIN_DIR)/tests $(LIBS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ -o $(BIN_DIR)/tests $(LIBS)
 
 tree_tests : $(TEST_OBJ_DIR)/tree_tests.o $(CORE_OBJ) $(TREE_OBJ) $(LIBHTS)
-	$(CXX) $(CXXFLAGS) $^ -o $(BIN_DIR)/tree_tests $(LIBS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ -o $(BIN_DIR)/tree_tests $(LIBS)
 
 speed_tree : $(TEST_OBJ_DIR)/speed_tree.o $(CORE_OBJ) $(TREE_OBJ) $(LIBHTS)
-	$(CXX) $(CXXFLAGS) $^ -o $(BIN_DIR)/speed_tree $(LIBS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ -o $(BIN_DIR)/speed_tree $(LIBS)
 
 interface : $(OBJ_DIR)/linhapexample.o $(OBJ_DIR)/interface.o $(CORE_OBJ) $(TREE_OBJ) $(LIBHTS)
-	$(CXX) $(CXXFLAGS) $^ -o $(BIN_DIR)/linhapexample $(LIBS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ -o $(BIN_DIR)/linhapexample $(LIBS)
 	
 serializer : $(OBJ_DIR)/serialize_index.o $(CORE_OBJ) $(LIBHTS)
-	$(CXX) $(CXXFLAGS) $^ -o $(BIN_DIR)/serializer $(LIBS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ -o $(BIN_DIR)/serializer $(LIBS)
 
 profiler : $(OBJ_DIR)/profiler.o $(CORE_OBJ)
-	$(CXX) $(CXXFLAGS) $^ -o $(BIN_DIR)/profiler $(LIBS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ -o $(BIN_DIR)/profiler $(LIBS)
 
 $(LIB_DIR)/libsublinearLS.a : $(CORE_OBJ) $(TREE_OBJ)
 	ar rc $@ $^
 	ranlib $@
 
 $(OBJ_DIR)/allele.o : $(SRC_DIR)/allele.cpp $(SRC_DIR)/allele.hpp
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -Wno-error=return-type $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(OBJ_DIR)/linhapexample.o : $(SRC_DIR)/linhapexample.c $(SRC_DIR)/interface.h $(SRC_DIR)/haplotype_manager.hpp $(SRC_DIR)/reference_sequence.hpp $(SRC_DIR)/set_of_extensions.hpp $(SRC_DIR)/haplotype_state_tree.hpp $(SRC_DIR)/haplotype_state_node.hpp $(PROBABILITY_DEPS)
 	gcc -std=c11 $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(OBJ_DIR)/interface.o : $(SRC_DIR)/interface.cpp $(SRC_DIR)/interface.h $(SRC_DIR)/haplotype_manager.hpp $(SRC_DIR)/reference_sequence.hpp $(SRC_DIR)/set_of_extensions.hpp $(SRC_DIR)/haplotype_state_tree.hpp $(SRC_DIR)/haplotype_state_node.hpp $(PROBABILITY_DEPS)
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(OBJ_DIR)/haplotype_state_node.o : $(SRC_DIR)/haplotype_state_node.cpp $(SRC_DIR)/haplotype_state_node.hpp $(PROBABILITY_DEPS)
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -Wno-error=return-type $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(OBJ_DIR)/haplotype_state_tree.o : $(SRC_DIR)/haplotype_state_tree.cpp $(SRC_DIR)/haplotype_state_tree.hpp $(SRC_DIR)/haplotype_state_node.hpp $(PROBABILITY_DEPS)
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(OBJ_DIR)/haplotype_manager.o : $(SRC_DIR)/haplotype_manager.cpp $(SRC_DIR)/haplotype_manager.hpp $(SRC_DIR)/reference_sequence.hpp $(SRC_DIR)/set_of_extensions.hpp $(SRC_DIR)/haplotype_state_tree.hpp $(SRC_DIR)/haplotype_state_node.hpp $(PROBABILITY_DEPS)
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(TEST_OBJ_DIR)/speed_tree.o : $(TEST_SRC_DIR)/speed_tree.cpp $(SRC_DIR)/haplotype_manager.hpp $(SRC_DIR)/reference_sequence.hpp $(SRC_DIR)/set_of_extensions.hpp $(SRC_DIR)/haplotype_state_tree.hpp $(SRC_DIR)/haplotype_state_node.hpp $(PROBABILITY_DEPS)
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(OBJ_DIR)/delay_multiplier.o : $(SRC_DIR)/delay_multiplier.cpp $(SRC_DIR)/delay_multiplier.hpp $(SRC_DIR)/math.hpp $(SRC_DIR)/DP_map.hpp $(SRC_DIR)/row_set.hpp
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(OBJ_DIR)/DP_map.o : $(SRC_DIR)/DP_map.cpp $(SRC_DIR)/math.hpp $(SRC_DIR)/DP_map.hpp
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(OBJ_DIR)/input_haplotype.o : $(SRC_DIR)/input_haplotype.cpp $(SRC_DIR)/input_haplotype.hpp $(SRC_DIR)/reference.hpp $(SRC_DIR)/allele.hpp
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(OBJ_DIR)/math.o : $(SRC_DIR)/math.cpp $(SRC_DIR)/math.hpp
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(OBJ_DIR)/probability.o : $(SRC_DIR)/probability.cpp $(PROBABILITY_DEPS)
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(OBJ_DIR)/penalty_set.o : $(SRC_DIR)/penalty_set.cpp $(SRC_DIR)/penalty_set.hpp $(SRC_DIR)/math.hpp $(SRC_DIR)/DP_map.hpp
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(OBJ_DIR)/reference.o : $(SRC_DIR)/reference.cpp $(SRC_DIR)/reference.hpp $(SRC_DIR)/allele.hpp $(SRC_DIR)/row_set.hpp
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(OBJ_DIR)/reference_sequence.o : $(SRC_DIR)/reference_sequence.cpp $(SRC_DIR)/reference_sequence.hpp $(SRC_DIR)/reference.hpp $(SRC_DIR)/allele.hpp
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(OBJ_DIR)/row_set.o : $(SRC_DIR)/row_set.cpp $(SRC_DIR)/row_set.hpp $(SRC_DIR)/allele.hpp
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(OBJ_DIR)/set_of_extensions.o : $(SRC_DIR)/set_of_extensions.cpp $(SRC_DIR)/set_of_extensions.hpp  $(PROBABILITY_DEPS)
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(TEST_OBJ_DIR)/test.o : $(TEST_SRC_DIR)/test.cpp $(PROBABILITY_DEPS)
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(TEST_OBJ_DIR)/tree_tests.o : $(TEST_SRC_DIR)/tree_tests.cpp $(SRC_DIR)/haplotype_manager.hpp $(SRC_DIR)/reference_sequence.hpp $(SRC_DIR)/set_of_extensions.hpp $(SRC_DIR)/haplotype_state_tree.hpp $(SRC_DIR)/haplotype_state_node.hpp $(PROBABILITY_DEPS)
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(OBJ_DIR)/serialize_index.o : $(SRC_DIR)/serialize_index.cpp $(SRC_DIR)/reference.hpp $(SRC_DIR)/allele.hpp $(SRC_DIR)/row_set.hpp
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@
 
 $(OBJ_DIR)/profiler.o : $(SRC_DIR)/test/profiler.cpp $(PROBABILITY_DEPS)
-	$(CXX) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@	
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE_FLAGS) $(LIBS) -c $< -o $@	
 
 $(LIBHTS) :
 	cd deps/htslib && make


### PR DESCRIPTION
Hello! This PR helps Debian enable build hardening. It was adapted from https://salsa.debian.org/med-team/vg/-/blob/a5a7bde0b1c3c0a02ed6559cb26989e0ad40df01/debian/patches/hardening_flags