### PR TITLE
Stop overriding CXX from environment

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,7 +8,6 @@ TEST_OBJ_DIR:=$(CWD)/obj/test
 LIB_DIR:= $(CWD)/lib
 DEP_DIR:= $(CWD)/deps
 
-CXX:=g++
 CXXFLAGS += -std=c++11 -g
 
 ifeq ($(INCLUDE_FLAGS),)


### PR DESCRIPTION
On Mac the rest of a vg build might be built with `c++` and not `g++`, and it's possible to be in a situation where those refer to different compilers. So if `CXX` is set to something other than the default coming into the build, the Makefile shouldn't override it.